### PR TITLE
split_sentences_fix

### DIFF
--- a/relatio/utils.py
+++ b/relatio/utils.py
@@ -56,7 +56,13 @@ def split_into_sentences(
         time.sleep(1)
         docs = tqdm(docs)
 
+    # Ready to be submitted now and test for merge
     for doc in docs:
+        if not (isinstance(doc["doc"], str)):
+            # Blank sentence (str format)
+            doc["doc"] = ""
+            doc_indices = doc_indices + [doc["id"]]
+        
         for sent in nlp(doc["doc"], disable=["tagger", "ner"]).sents:
             sentences.append(str(sent))
             doc_indices = doc_indices + [doc["id"]]


### PR DESCRIPTION
When I used the split_into_sentences method for my .csv files, I came across this issue of blank entries in text fields, which are treated as NaN in the df object on which the method is run. Due to this, the len() method in split_into_sentences() failed as it is not defined for float (NaN) type. I used df.fillna("", inplace=True) inside my DataFrame to solve this but finding this error required a lot of work, it wasn't explicit. It should be a good idea to handle this issue at the source itself, either with correction or with better error messages, pointing to the solution.