### PR TITLE
Dimension reduction of embeddings before clustering

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,3 +34,4 @@ install_requires =
     requests>=2
     umap-learn==0.5.3
     hdbscan==0.8.28
+    wpca==0.1


### PR DESCRIPTION
Writing codes for issue #75.

Adding an option (weight_by_frequency) for allowing duplicate entities for dimension reduction and clustering.

If weight_by_frequency is true, dimension reduction and clustering are conducted with duplicate entities (clustering is weighted by each frequency).
If weight_by_frequency is false, dimension reduction and clustering are conducted with unique entities.

I also added different PCA options: incremental PCA and weighted PCA